### PR TITLE
Add long-press backdating for device status changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Uses `SharedPreferences` with these keys:
   - `DeviceLocation` (body-specific locations filtered by device type)
   - `EventType` (watchTv/inBed/lightsOut/walk/run/workout/swim/other)
 - **Time Windows**: Events support earliest/latest timestamps for retroactive logging uncertainty
+- **Backdating**: Long-press on W/L/C status buttons shows preset times (15m, 30m, 1h, 2h ago) or custom time picker for retroactive status changes
 - **Validation**: DeviceStore throws exceptions for duplicate device names
 - **Persistent Notifications**: Silent, ongoing notifications display active events and durations (auto-updated when events start/stop)
 - **Tracking State**: Defaults to paused on first launch; device config editable when paused
@@ -128,6 +129,7 @@ Tab-separated entries with UTC ISO 8601 timestamps. Time windows use `..` separa
 2024-01-15T10:30:00.000Z	DEVICE_ADDED	uuid	name="MyWatch"	type=watch	status=loose	location=leftWrist	sn=SN123	power=on
 2024-01-15T10:32:00.000Z	DEVICE_UPDATED	uuid	"MyWatch"	name="My Watch Renamed"	type=wristband	sn=SN456	status=worn	location=rightWrist	power=off
 2024-01-15T10:45:00.000Z	DEVICE_UPDATED	uuid	"My Watch Renamed"	status=loose
+2024-01-15T10:50:00.000Z	DEVICE_UPDATED	uuid	"My Watch Renamed"	status=worn	effective=2024-01-15T10:35:00.000Z
 2024-01-15T11:00:00.000Z	EVENT_STARTED	uuid	walk	2024-01-15T11:00:00.000Z
 2024-01-15T11:30:00.000Z	EVENT_STOPPED	uuid	walk	2024-01-15T11:00:00.000Z	2024-01-15T11:25:00.000Z..2024-01-15T11:30:00.000Z
 2024-01-15T12:00:00.000Z	NOTE	User added a custom note

--- a/lib/screens/logs_screen.dart
+++ b/lib/screens/logs_screen.dart
@@ -1358,8 +1358,6 @@ class _BackdateBottomSheet extends StatefulWidget {
 }
 
 class _BackdateBottomSheetState extends State<_BackdateBottomSheet> {
-  DateTime? _customTime;
-
   String _formatTimeAgo(Duration d) {
     if (d.inMinutes < 60) {
       return '${d.inMinutes}m ago';

--- a/lib/screens/logs_screen.dart
+++ b/lib/screens/logs_screen.dart
@@ -226,7 +226,11 @@ class _LogsScreenState extends State<LogsScreen> {
     }
   }
 
-  Future<void> _changeStatus(Device device, DeviceStatus newStatus) async {
+  Future<void> _changeStatus(
+    Device device,
+    DeviceStatus newStatus, {
+    DateTime? effectiveTime,
+  }) async {
     if (!_isTracking) {
       _showTrackingPausedWarning();
       return;
@@ -234,9 +238,30 @@ class _LogsScreenState extends State<LogsScreen> {
     if (newStatus == device.status) return;
     final updated = device.copyWith(status: newStatus);
     await DeviceStore.instance.updateDevice(updated);
-    await LogService.instance.logDeviceUpdated(device, updated);
+    await LogService.instance.logDeviceUpdated(
+      device,
+      updated,
+      effectiveTime: effectiveTime,
+    );
     await NotificationService.instance.updateDeviceNotification(updated);
     _load();
+  }
+
+  Future<void> _showBackdateStatusSheet(Device device, DeviceStatus newStatus) async {
+    if (!_isTracking) {
+      _showTrackingPausedWarning();
+      return;
+    }
+
+    final now = DateTime.now();
+    final result = await showModalBottomSheet<DateTime?>(
+      context: context,
+      builder: (ctx) => _BackdateBottomSheet(now: now),
+    );
+
+    if (result != null && mounted) {
+      await _changeStatus(device, newStatus, effectiveTime: result);
+    }
   }
 
   Future<void> _addDeviceNote(Device device) async {
@@ -380,28 +405,39 @@ class _LogsScreenState extends State<LogsScreen> {
   }
 
   Widget _statusToggle(Device d) {
-    return ToggleButtons(
-      isSelected: [
-        d.status == DeviceStatus.worn,
-        d.status == DeviceStatus.loose,
-        d.status == DeviceStatus.charging,
-      ],
-      onPressed: (index) {
-        final status = DeviceStatus.values[index];
-        _changeStatus(d, status);
-      },
-      constraints: const BoxConstraints(minWidth: 32, minHeight: 28),
-      borderRadius: BorderRadius.circular(4),
-      selectedColor: Colors.white,
-      fillColor: d.status == DeviceStatus.worn
-          ? Colors.orange
-          : d.status == DeviceStatus.charging
-              ? Colors.green
-              : Colors.grey,
-      children: const [
-        Padding(padding: EdgeInsets.symmetric(horizontal: 6), child: Text('W', style: TextStyle(fontSize: 12))),
-        Padding(padding: EdgeInsets.symmetric(horizontal: 6), child: Text('L', style: TextStyle(fontSize: 12))),
-        Padding(padding: EdgeInsets.symmetric(horizontal: 6), child: Text('C', style: TextStyle(fontSize: 12))),
+    Widget buildButton(DeviceStatus status, String label, Color activeColor) {
+      final isSelected = d.status == status;
+      return GestureDetector(
+        onTap: () => _changeStatus(d, status),
+        onLongPress: () => _showBackdateStatusSheet(d, status),
+        child: Container(
+          constraints: const BoxConstraints(minWidth: 32, minHeight: 28),
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          decoration: BoxDecoration(
+            color: isSelected ? activeColor : null,
+            border: Border.all(color: activeColor.withValues(alpha: 0.5)),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: isSelected ? Colors.white : null,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        buildButton(DeviceStatus.worn, 'W', Colors.orange),
+        const SizedBox(width: 2),
+        buildButton(DeviceStatus.loose, 'L', Colors.grey),
+        const SizedBox(width: 2),
+        buildButton(DeviceStatus.charging, 'C', Colors.green),
       ],
     );
   }
@@ -1309,6 +1345,120 @@ class _StopEventDialogState extends State<StopEventDialog> {
         TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
         TextButton(onPressed: _submit, child: const Text('Stop')),
       ],
+    );
+  }
+}
+
+class _BackdateBottomSheet extends StatefulWidget {
+  final DateTime now;
+  const _BackdateBottomSheet({required this.now});
+
+  @override
+  State<_BackdateBottomSheet> createState() => _BackdateBottomSheetState();
+}
+
+class _BackdateBottomSheetState extends State<_BackdateBottomSheet> {
+  DateTime? _customTime;
+
+  String _formatTimeAgo(Duration d) {
+    if (d.inMinutes < 60) {
+      return '${d.inMinutes}m ago';
+    }
+    final hours = d.inHours;
+    final minutes = d.inMinutes % 60;
+    if (minutes == 0) {
+      return '${hours}h ago';
+    }
+    return '${hours}h ${minutes}m ago';
+  }
+
+  Future<void> _pickCustomTime() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: widget.now,
+      firstDate: widget.now.subtract(const Duration(days: 7)),
+      lastDate: widget.now,
+    );
+    if (date == null || !mounted) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(widget.now),
+    );
+    if (time == null || !mounted) return;
+
+    final combined = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+
+    // Validate not in future
+    if (combined.isAfter(widget.now)) {
+      await showDialog(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Invalid Time'),
+          content: const Text('Effective time cannot be in the future.'),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('OK')),
+          ],
+        ),
+      );
+      return;
+    }
+
+    if (mounted) {
+      Navigator.pop(context, combined);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final presets = [
+      const Duration(minutes: 15),
+      const Duration(minutes: 30),
+      const Duration(hours: 1),
+      const Duration(hours: 2),
+    ];
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'When did this happen?',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              alignment: WrapAlignment.center,
+              children: [
+                for (final preset in presets)
+                  ActionChip(
+                    label: Text(_formatTimeAgo(preset)),
+                    onPressed: () {
+                      Navigator.pop(context, widget.now.subtract(preset));
+                    },
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: _pickCustomTime,
+              icon: const Icon(Icons.access_time),
+              label: const Text('Custom time...'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -50,7 +50,11 @@ class LogService {
     );
   }
 
-  Future<void> logDeviceUpdated(Device oldDevice, Device newDevice) async {
+  Future<void> logDeviceUpdated(
+    Device oldDevice,
+    Device newDevice, {
+    DateTime? effectiveTime,
+  }) async {
     final changes = <String>[];
 
     if (oldDevice.name != newDevice.name) {
@@ -73,6 +77,11 @@ class LogService {
     }
 
     if (changes.isEmpty) return;
+
+    // Add effective timestamp if backdated
+    if (effectiveTime != null) {
+      changes.add('effective=${effectiveTime.toUtc().toIso8601String()}');
+    }
 
     await _append(
       '${_timestamp()}\tDEVICE_UPDATED\t${newDevice.id}\t"${oldDevice.name}"\t${changes.join('\t')}',


### PR DESCRIPTION
## Summary

Addresses #10 - allows retroactive logging of device status changes.

- Long-press on W/L/C status buttons opens a bottom sheet with preset times (15m, 30m, 1h, 2h ago) or custom time picker
- Backdated changes are logged with an `effective=<timestamp>` field while the log timestamp reflects when the entry was actually recorded
- Validates that effective time cannot be in the future
- Custom picker allows up to 7 days in the past
- Notification action buttons remain instant (tap-only) for quick logging

## Test plan

- [x] Long-press on W/L/C button shows bottom sheet with time presets
- [x] Tapping a preset (e.g., "30m ago") changes status and logs with `effective=` timestamp
- [x] "Custom time..." opens date then time picker
- [x] Selecting a future time shows error dialog
- [x] Regular tap on W/L/C still works for instant status change (no `effective=` in log)
- [x] Notification W/L/C buttons still work as instant tap-to-change

🤖 Generated with [Claude Code](https://claude.ai/code)