### PR TITLE
Add share as file option for log export

### DIFF
--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -1,8 +1,7 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/file_sharer.dart';
 import '../services/log_service.dart';
 
 class HistoryScreen extends StatefulWidget {
@@ -49,13 +48,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
   Future<void> _shareLogAsFile() async {
     try {
       final content = await LogService.instance.getLogContent();
-      final tempDir = await getTemporaryDirectory();
-      final file = File('${tempDir.path}/worn_log.txt');
-      await file.writeAsString(content);
-      await Share.shareXFiles(
-        [XFile(file.path)],
-        subject: 'Worn Log Export',
-      );
+      await shareLogAsFile(content);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -170,16 +163,17 @@ class _HistoryScreenState extends State<HistoryScreen> {
                   ],
                 ),
               ),
-              const PopupMenuItem(
-                value: 'file',
-                child: Row(
-                  children: [
-                    Icon(Icons.insert_drive_file),
-                    SizedBox(width: 8),
-                    Text('Share as file'),
-                  ],
+              if (isFileShareSupported)
+                const PopupMenuItem(
+                  value: 'file',
+                  child: Row(
+                    children: [
+                      Icon(Icons.insert_drive_file),
+                      SizedBox(width: 8),
+                      Text('Share as file'),
+                    ],
+                  ),
                 ),
-              ),
             ],
           ),
           PopupMenuButton<String>(

--- a/lib/services/file_sharer.dart
+++ b/lib/services/file_sharer.dart
@@ -1,0 +1,1 @@
+export 'file_sharer_stub.dart' if (dart.library.io) 'file_sharer_io.dart';

--- a/lib/services/file_sharer_io.dart
+++ b/lib/services/file_sharer_io.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// IO implementation for mobile/desktop - creates temp file and shares
+Future<void> shareLogAsFile(String content) async {
+  final tempDir = await getTemporaryDirectory();
+  final file = File('${tempDir.path}/worn_log.txt');
+  await file.writeAsString(content);
+  await Share.shareXFiles(
+    [XFile(file.path)],
+    subject: 'Worn Log Export',
+  );
+}
+
+/// Returns true if file sharing is supported on this platform
+bool get isFileShareSupported => true;

--- a/lib/services/file_sharer_stub.dart
+++ b/lib/services/file_sharer_stub.dart
@@ -1,0 +1,10 @@
+import 'package:share_plus/share_plus.dart';
+
+/// Stub implementation for web - file sharing not supported
+Future<void> shareLogAsFile(String content) async {
+  // On web, fall back to text sharing
+  await Share.share(content, subject: 'Worn Log Export');
+}
+
+/// Returns true if file sharing is supported on this platform
+bool get isFileShareSupported => false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,7 +305,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   shared_preferences: ^2.2.0
   url_launcher: ^6.2.0
   share_plus: ^7.2.1
+  path_provider: ^2.1.0
   awesome_notifications: ^0.10.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Adds a popup menu to the share button with two options: "Share as text" and "Share as file"
- Share as file creates a `worn_log.txt` temp file and shares it as an attachment
- Added `path_provider` dependency to create the temp file

Closes #51

## Test plan
- [x] Tap share button and verify menu appears with two options
- [x] Test "Share as text" works as before (inserts into email/message body)
- [x] Test "Share as file" shares a .txt file attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)