### PR TITLE
Fix event log format and add validations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,19 @@ Uses `SharedPreferences` with these keys:
 
 ## Log Format
 
-Tab-separated entries with ISO 8601 timestamps including timezone offset (e.g., `-05:00`). When events have time windows (uncertainty), `earliest=` and `latest=` key=value pairs are appended. When there is no time window, the log entry's timestamp IS the event time (no separate timestamp appended). Uses internal variable names for parsing efficiency:
+Tab-separated entries with ISO 8601 timestamps including timezone offset (e.g., `-05:00`). Event times are handled as follows:
+- **Current time** (within 60s of log time): No separate timestamp (log entry timestamp IS the event time)
+- **Backdated precise time**: Single timestamp appended
+- **Time window** (uncertainty): `earliest=` and `latest=` key=value pairs appended
+
+Uses internal variable names for parsing efficiency:
 ```
 2024-01-15T10:30:00.000-05:00	DEVICE_ADDED	uuid	name="MyWatch"	type=watch	status=loose	location=leftWrist	sn=SN123	power=on
 2024-01-15T10:32:00.000-05:00	DEVICE_UPDATED	uuid	"MyWatch"	name="My Watch Renamed"	type=wristband	sn=SN456	status=worn	location=rightWrist	power=off
 2024-01-15T10:45:00.000-05:00	DEVICE_UPDATED	uuid	"My Watch Renamed"	status=loose
 2024-01-15T11:00:00.000-05:00	EVENT_STARTED	uuid	walk
 2024-01-15T11:05:00.000-05:00	EVENT_STARTED	uuid	run	earliest=2024-01-15T11:00:00.000-05:00	latest=2024-01-15T11:05:00.000-05:00
+2024-01-15T11:10:00.000-05:00	EVENT_STARTED	uuid	workout	2024-01-15T10:45:00.000-05:00
 2024-01-15T11:30:00.000-05:00	EVENT_STOPPED	uuid	walk
 2024-01-15T11:35:00.000-05:00	EVENT_STOPPED	uuid	run	earliest=2024-01-15T11:30:00.000-05:00	latest=2024-01-15T11:35:00.000-05:00
 2024-01-15T11:40:00.000-05:00	EVENT_CANCELLED	uuid	swim

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Uses `SharedPreferences` with these keys:
   - `DeviceType` (watch, ring, wristband, armband, chestStrap, headband, other) with icons
   - `DeviceStatus` (worn, loose, charging) for quick status toggle
   - `DeviceLocation` (body-specific locations filtered by device type)
-  - `EventType` (watchTv/inBed/lightsOut/walk/run/workout/swim/other)
+  - `EventType` (inBed/lightsOut/walk/run/workout/swim/watchTv/other)
 - **Time Windows**: Events support earliest/latest timestamps for retroactive logging uncertainty
 - **Backdating**: Long-press on W/L/C status buttons shows preset times (15m, 30m, 1h, 2h ago) or custom time picker for retroactive status changes
 - **Validation**: DeviceStore throws exceptions for duplicate device names
@@ -124,14 +124,16 @@ Uses `SharedPreferences` with these keys:
 
 ## Log Format
 
-Tab-separated entries with ISO 8601 timestamps including timezone offset (e.g., `-05:00`). Time windows with different earliest/latest use key=value pairs. Uses internal variable names for parsing efficiency:
+Tab-separated entries with ISO 8601 timestamps including timezone offset (e.g., `-05:00`). When events have time windows (uncertainty), `earliest=` and `latest=` key=value pairs are appended. When there is no time window, the log entry's timestamp IS the event time (no separate timestamp appended). Uses internal variable names for parsing efficiency:
 ```
 2024-01-15T10:30:00.000-05:00	DEVICE_ADDED	uuid	name="MyWatch"	type=watch	status=loose	location=leftWrist	sn=SN123	power=on
 2024-01-15T10:32:00.000-05:00	DEVICE_UPDATED	uuid	"MyWatch"	name="My Watch Renamed"	type=wristband	sn=SN456	status=worn	location=rightWrist	power=off
 2024-01-15T10:45:00.000-05:00	DEVICE_UPDATED	uuid	"My Watch Renamed"	status=loose
-2024-01-15T11:00:00.000-05:00	EVENT_STARTED	uuid	walk	2024-01-15T11:00:00.000-05:00
-2024-01-15T11:30:00.000-05:00	EVENT_STOPPED	uuid	walk	2024-01-15T11:00:00.000-05:00	earliest=2024-01-15T11:25:00.000-05:00	latest=2024-01-15T11:30:00.000-05:00
-2024-01-15T11:35:00.000-05:00	EVENT_CANCELLED	uuid	walk
+2024-01-15T11:00:00.000-05:00	EVENT_STARTED	uuid	walk
+2024-01-15T11:05:00.000-05:00	EVENT_STARTED	uuid	run	earliest=2024-01-15T11:00:00.000-05:00	latest=2024-01-15T11:05:00.000-05:00
+2024-01-15T11:30:00.000-05:00	EVENT_STOPPED	uuid	walk
+2024-01-15T11:35:00.000-05:00	EVENT_STOPPED	uuid	run	earliest=2024-01-15T11:30:00.000-05:00	latest=2024-01-15T11:35:00.000-05:00
+2024-01-15T11:40:00.000-05:00	EVENT_CANCELLED	uuid	swim
 2024-01-15T12:00:00.000-05:00	GLOBAL_NOTE	User added a custom note
 2024-01-15T12:05:00.000-05:00	DEVICE_NOTE	uuid	MyWatch	Device-specific note
 2024-01-15T12:10:00.000-05:00	ACTIVITY_NOTE	eventId	Walk	Event-specific note

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,13 +1,13 @@
 import 'package:uuid/uuid.dart';
 
 enum EventType {
-  watchTv,
   inBed,
   lightsOut,
   walk,
   run,
   workout,
   swim,
+  watchTv,
   other,
 }
 

--- a/lib/screens/logs_screen.dart
+++ b/lib/screens/logs_screen.dart
@@ -1075,6 +1075,11 @@ class _AddEventDialogState extends State<AddEventDialog> {
       if (startLatest.isAfter(stopEarliest)) {
         return 'Start latest time cannot be after stop earliest time.';
       }
+
+      // Retroactive events must have non-zero duration
+      if (startLatest == stopEarliest) {
+        return 'Start and stop times cannot be the same for retroactive events.';
+      }
     }
 
     return null;

--- a/lib/services/log_service.dart
+++ b/lib/services/log_service.dart
@@ -117,18 +117,27 @@ class LogService {
     }
   }
 
-  String _formatTimeWindow(DateTime earliest, DateTime latest) {
+  /// Formats a time window. Returns null if no window (earliest == latest).
+  /// When there is a window, returns 'earliest=...\tlatest=...'
+  String? _formatTimeWindow(DateTime earliest, DateTime latest) {
     if (earliest == latest) {
-      return _formatDateTime(earliest);
+      return null;
     }
     return 'earliest=${_formatDateTime(earliest)}\tlatest=${_formatDateTime(latest)}';
   }
 
   Future<void> logEventStarted(Event event) async {
     final startWindow = _formatTimeWindow(event.startEarliest, event.startLatest);
-    await _append(
-      '${_timestamp()}\tEVENT_STARTED\t${event.id}\t${event.type.name}\t$startWindow',
-    );
+    final parts = [
+      _timestamp(),
+      'EVENT_STARTED',
+      event.id,
+      event.type.name,
+    ];
+    if (startWindow != null) {
+      parts.add(startWindow);
+    }
+    await _append(parts.join('\t'));
   }
 
   Future<void> logEventStopped(
@@ -138,9 +147,19 @@ class LogService {
   ) async {
     final startWindow = _formatTimeWindow(event.startEarliest, event.startLatest);
     final stopWindow = _formatTimeWindow(stopEarliest, stopLatest);
-    await _append(
-      '${_timestamp()}\tEVENT_STOPPED\t${event.id}\t${event.type.name}\t$startWindow\t$stopWindow',
-    );
+    final parts = [
+      _timestamp(),
+      'EVENT_STOPPED',
+      event.id,
+      event.type.name,
+    ];
+    if (startWindow != null) {
+      parts.add(startWindow);
+    }
+    if (stopWindow != null) {
+      parts.add(stopWindow);
+    }
+    await _append(parts.join('\t'));
   }
 
   Future<void> logEventCancelled(Event event) async {
@@ -156,9 +175,19 @@ class LogService {
   ) async {
     final startWindow = _formatTimeWindow(event.startEarliest, event.startLatest);
     final stopWindow = _formatTimeWindow(stopEarliest, stopLatest);
-    await _append(
-      '${_timestamp()}\tEVENT_RETROACTIVE\t${event.id}\t${event.type.name}\t$startWindow\t$stopWindow',
-    );
+    final parts = [
+      _timestamp(),
+      'EVENT_RETROACTIVE',
+      event.id,
+      event.type.name,
+    ];
+    if (startWindow != null) {
+      parts.add(startWindow);
+    }
+    if (stopWindow != null) {
+      parts.add(stopWindow);
+    }
+    await _append(parts.join('\t'));
   }
 
   Future<List<String>> getLogLines() async {

--- a/test/log_service_test.dart
+++ b/test/log_service_test.dart
@@ -225,7 +225,7 @@ void main() {
       LogService.resetForTesting();
     });
 
-    test('logEventStarted with same earliest/latest outputs single timestamp', () async {
+    test('logEventStarted with same earliest/latest omits timestamp', () async {
       final service = LogService.instance;
       final time = DateTime.utc(2024, 1, 15, 10, 30);
       final event = Event(
@@ -240,11 +240,11 @@ void main() {
       final logLines = await service.getLogLines();
       final logLine = logLines.first;
 
-      // Should contain single timestamp, not earliest=/latest= format
+      // Should NOT contain any time window - the log timestamp IS the event time
       expect(logLine, isNot(contains('earliest=')));
       expect(logLine, isNot(contains('latest=')));
-      // Should contain the timestamp directly after event type
-      expect(logLine, contains('walk\t'));
+      // Log line should end with the event type (no trailing timestamp)
+      expect(logLine, endsWith('walk'));
     });
 
     test('logEventStarted with different earliest/latest outputs key=value pairs', () async {

--- a/test/log_service_test.dart
+++ b/test/log_service_test.dart
@@ -225,14 +225,15 @@ void main() {
       LogService.resetForTesting();
     });
 
-    test('logEventStarted with same earliest/latest omits timestamp', () async {
+    test('logEventStarted with same earliest/latest near now omits timestamp', () async {
       final service = LogService.instance;
-      final time = DateTime.utc(2024, 1, 15, 10, 30);
+      // Use current time (within 60 seconds tolerance)
+      final now = DateTime.now().toUtc();
       final event = Event(
         id: 'test-id',
         type: EventType.walk,
-        startEarliest: time,
-        startLatest: time,
+        startEarliest: now,
+        startLatest: now,
       );
 
       await service.logEventStarted(event);
@@ -245,6 +246,32 @@ void main() {
       expect(logLine, isNot(contains('latest=')));
       // Log line should end with the event type (no trailing timestamp)
       expect(logLine, endsWith('walk'));
+    });
+
+    test('logEventStarted with same earliest/latest backdated outputs single timestamp', () async {
+      final service = LogService.instance;
+      // Use a backdated time (more than 60 seconds in the past)
+      final backdatedTime = DateTime.utc(2024, 1, 15, 10, 30);
+      final event = Event(
+        id: 'test-id',
+        type: EventType.run,
+        startEarliest: backdatedTime,
+        startLatest: backdatedTime,
+      );
+
+      await service.logEventStarted(event);
+
+      final logLines = await service.getLogLines();
+      final logLine = logLines.first;
+
+      // Should NOT contain earliest=/latest= format (not a window)
+      expect(logLine, isNot(contains('earliest=')));
+      expect(logLine, isNot(contains('latest=')));
+      // Should contain a backdated timestamp (2024-01-15, converted to local timezone)
+      expect(logLine, contains('2024-01-15'));
+      // Should have more fields than just timestamp + type (includes backdated time)
+      final fields = logLine.split('\t');
+      expect(fields.length, 5); // timestamp, EVENT_STARTED, id, type, backdated_time
     });
 
     test('logEventStarted with different earliest/latest outputs key=value pairs', () async {


### PR DESCRIPTION
## Summary
- Events without time windows no longer output redundant timestamps (the log entry timestamp IS the event time)
- Events with time windows use `earliest=`/`latest=` key=value format
- Added validation: retroactive events must have non-zero duration (start != stop)
- Moved "Watch TV" event type lower in the list (between Swim and Other)
- Updated CLAUDE.md documentation to reflect new log format

Closes #50

## Test plan
- [x] Create an event with current time (no window) - log should NOT have timestamps after event type
- [x] Create an event with a time window - log should have `earliest=` and `latest=` fields
- [x] Stop an event with current time (no window) - log should NOT have timestamps for stop time
- [x] Stop an event with a time window - log should have `earliest=` and `latest=` for stop time
- [x] Try to create a retroactive event where start == stop - should show validation error
- [x] Verify "Watch TV" appears between "Swim" and "Other" in event type list

🤖 Generated with [Claude Code](https://claude.com/claude-code)